### PR TITLE
Spacebar and Up button freezes the game

### DIFF
--- a/main.py
+++ b/main.py
@@ -170,10 +170,10 @@ class Flappy():
                 if event.type == pygame.QUIT:
                     self.running = False
                 elif event.type == pygame.MOUSEBUTTONDOWN or (
-                    event.type == pygame.KEYDOWN and any(
+                    event.type == pygame.KEYDOWN and any((
                         event.key == pygame.K_SPACE,
                         event.key == pygame.K_UP
-                    )
+                    ))
                 ):
                     if self.state == INIT:
                         self.state = PLAY


### PR DESCRIPTION
The problem was caused because `Spacebar` button and `up` Buttons were not handled properly in the `pygame loop`.

It was generating an error
```
Traceback (most recent call last):
  File "Flappy.activity/main.py", line 173, in run
    event.type == pygame.KEYDOWN and any(
                                     ^^^^
TypeError: any() takes exactly one argument (2 given)
```